### PR TITLE
feat: Wails v3 desktop app for NetCatcher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,6 +108,13 @@ jobs:
           </plist>
           PLIST
 
+          # Re-sign the Mach-O with the bundle identifier. The Go linker-signed
+          # "a.out" identifier doesn't match CFBundleIdentifier, which on
+          # macOS Sequoia causes "is damaged" errors once the DMG is opened
+          # (com.apple.quarantine + mismatched identifier trips Gatekeeper).
+          codesign --force --sign - --identifier com.attson.netcatcher \
+            "$APP/Contents/MacOS/NetCatcher"
+
           DMG_DIR="build/dmg-contents"
           mkdir -p "$DMG_DIR"
           mv build/NetCatcher.app "$DMG_DIR/"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Download the latest release from the [Releases](https://github.com/attson/netcat
 
 **macOS:** Open the `.dmg` and drag NetCatcher to Applications. On first route operation the app prompts for your admin password once — no need for `sudo`.
 
+> **"NetCatcher is damaged and can't be opened"?** The app is ad-hoc signed, not notarized with an Apple Developer ID, so Gatekeeper rejects it once macOS adds the quarantine attribute during DMG download. Remove the attribute once:
+>
+> ```bash
+> sudo xattr -cr /Applications/NetCatcher.app
+> ```
+>
+> Then open normally. You only need to do this after each update.
+
 **Windows:** Run `NetCatcher-amd64.exe` as Administrator.
 
 ## Building from Source

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,14 @@ NetCatcher 是一个桌面应用，用于监控网络接口并在连接时自动
 
 **macOS：** 打开 `.dmg` 文件，将 NetCatcher 拖入"应用程序"文件夹。首次添加路由时会弹出密码输入框请求授权，之后无需重复输入。
 
+> **提示 "NetCatcher 已损坏，无法打开"？** 应用只做了 ad-hoc 签名，没有经过 Apple Developer ID 公证，所以下载 DMG 时 macOS 加上的 quarantine 属性会被 Gatekeeper 拦截。执行一次以下命令即可：
+>
+> ```bash
+> sudo xattr -cr /Applications/NetCatcher.app
+> ```
+>
+> 然后正常打开。每次更新后重复一次即可。
+
 **Windows：** 以管理员身份运行 `NetCatcher-amd64.exe`。
 
 ## 从源码构建

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -68,9 +68,18 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
 </plist>
 PLIST
 
-# Ad-hoc sign so the bundle identifier is honored (unsigned bundles can
-# have notification delivery quirks on macOS).
-codesign --force --deep --sign - "$APP" >/dev/null 2>&1 || true
+# Re-sign the Mach-O with the bundle identifier so the embedded signature
+# (Go's linker-signed "a.out" identifier) matches CFBundleIdentifier. On
+# macOS Sequoia the mismatch triggers "is damaged" errors.
+codesign --force --sign - --identifier com.attson.netcatcher \
+  "$APP/Contents/MacOS/NetCatcher"
+
+# Strip extended attributes that can trip Gatekeeper on locally-built apps.
+xattr -cr "$APP" 2>/dev/null || true
 
 echo "==> Done: $APP"
+echo
 echo "Run with: open $APP"
+echo
+echo "If macOS says '\"NetCatcher\" 已损坏' or '\"NetCatcher\" is damaged':"
+echo "  sudo xattr -cr $APP && open $APP"


### PR DESCRIPTION
## Summary

Converts NetCatcher from a CLI tool into a cross-platform desktop app built on Wails v3 + Vue 3.

- **Frontend**: Vue 3 + Pinia + vue-i18n (English + Chinese). Dashboard with inline route editing, real-time log viewer, settings panel. System interfaces shown as a dropdown with VPN service names (resolved via `scutil --nc list` on macOS).
- **Backend**: `Manager` owns per-interface `NetCatcher` goroutines; status changes are pushed to the frontend over Wails events.
- **macOS privileges**: single `osascript` admin prompt on startup creates a sudoers rule so subsequent `/sbin/route` calls run without password. Cleanup on shutdown.
- **System notifications**: native Wails `NotificationService` (macOS `UserNotifications` framework, Windows Toast) — replaces `beeep`, which was routing through `osascript` and silently dropped on modern macOS.
- **System tray**: closing the window hides it; quit via tray menu.
- **Packaging**: release workflow produces `.dmg` (arm64 + amd64) and `.exe` (amd64). Local `scripts/build-app.sh` mirrors the CI packaging for dev testing.
- **Gatekeeper fix**: Mach-O is re-signed with the bundle identifier so it matches `CFBundleIdentifier`; without this macOS Sequoia rejects the DMG-delivered app as "damaged". README documents the `sudo xattr -cr` fallback for end users.

## Test plan

- [ ] `go test ./config/ ./logbuffer/ ./netcatcher/` and `go test -run TestManager` pass
- [ ] `scripts/build-app.sh` produces a working `.app` locally; notifications fire on VPN connect/disconnect with NetCatcher attribution
- [ ] Release workflow builds both macOS DMGs and Windows EXE; installed DMG launches on macOS 15 after `sudo xattr -cr`
- [ ] First route operation prompts for admin password exactly once, subsequent route changes run silently
- [ ] Settings notifications toggle persists and actually disables notifications
- [ ] Loose binary `./build/bin/netcatcher-app` still starts on macOS (logs `system notifications unavailable`)
- [ ] Language switcher toggles UI between English and Chinese; selection persists via `localStorage`