### PR TITLE
feat: inject build-time version into Settings About and Info.plist

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Compute version
+        id: ver
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -45,6 +50,8 @@ jobs:
         run: cd frontend && npm ci
 
       - name: Build frontend
+        env:
+          APP_VERSION: ${{ steps.ver.outputs.version }}
         run: cd frontend && npx vite build
 
       - name: Build Go binary
@@ -59,6 +66,8 @@ jobs:
 
       - name: Package macOS .dmg
         if: matrix.platform == 'darwin'
+        env:
+          APP_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           APP="build/NetCatcher.app"
           mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
@@ -81,7 +90,7 @@ jobs:
           iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/appicon.icns"
           rm -rf "$ICONSET"
 
-          cat > "$APP/Contents/Info.plist" << 'PLIST'
+          cat > "$APP/Contents/Info.plist" << PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -95,9 +104,9 @@ jobs:
             <key>CFBundleName</key>
             <string>NetCatcher</string>
             <key>CFBundleVersion</key>
-            <string>1.0.0</string>
+            <string>${APP_VERSION}</string>
             <key>CFBundleShortVersionString</key>
-            <string>1.0.0</string>
+            <string>${APP_VERSION}</string>
             <key>CFBundlePackageType</key>
             <string>APPL</string>
             <key>LSUIElement</key>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,16 @@ GitHub Actions workflow at `.github/workflows/release.yaml` triggers on tag push
 
 The CI does NOT use `wails3 build` (which requires a Taskfile). It runs `npx vite build` + `go build` directly.
 
+### Versioning
+
+The version shown in Settings > About and in the macOS `Info.plist` is injected at build time:
+
+- CI (tag push): derived from the git tag, e.g. `v1.2.3` → `1.2.3`.
+- Local build: `vite.config.js` runs `git rev-parse --short HEAD` and uses `dev-<sha>`; falls back to `dev` if not in a git repo.
+- Override: set `APP_VERSION` env var before `npx vite build` (and before the macOS packaging step) to force a specific version.
+
+Vite exposes the resolved value as the global `__APP_VERSION__`, read by `frontend/src/views/Settings.vue`. The i18n strings use a `{version}` placeholder.
+
 ### Tests
 
 ```bash

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -65,6 +65,6 @@
   "settings.about": "About",
   "settings.appName": "NetCatcher",
   "settings.appDesc": "— Network route manager",
-  "settings.version": "Version: 1.0.0",
+  "settings.version": "Version: {version}",
   "settings.github": "GitHub Repository"
 }

--- a/frontend/src/i18n/zh-CN.json
+++ b/frontend/src/i18n/zh-CN.json
@@ -65,6 +65,6 @@
   "settings.about": "关于",
   "settings.appName": "NetCatcher",
   "settings.appDesc": "— 网络路由管理器",
-  "settings.version": "版本：1.0.0",
+  "settings.version": "版本：{version}",
   "settings.github": "GitHub 仓库"
 }

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -10,6 +10,7 @@ const autoStart = ref(false)
 const notifications = ref(true)
 const currentLocale = ref(locale.value)
 const loading = ref(true)
+const appVersion = __APP_VERSION__
 
 onMounted(async () => {
   await configStore.fetchConfigPath()
@@ -93,7 +94,7 @@ function changeLocale() {
       <h2>{{ $t('settings.about') }}</h2>
       <div style="padding: 8px 0; color: var(--text-secondary); font-size: 13px;">
         <div style="margin-bottom: 4px;"><span style="color: var(--text-primary);">{{ $t('settings.appName') }}</span> {{ $t('settings.appDesc') }}</div>
-        <div style="margin-bottom: 4px;">{{ $t('settings.version') }}</div>
+        <div style="margin-bottom: 4px;">{{ $t('settings.version', { version: appVersion }) }}</div>
         <div><a href="https://github.com/attson/netcatcher" target="_blank" style="color: var(--text-link); text-decoration: none;">{{ $t('settings.github') }}</a></div>
       </div>
     </div>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,23 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { execSync } from 'node:child_process'
+
+function resolveVersion() {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION
+  try {
+    const sha = execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim()
+    return sha ? `dev-${sha}` : 'dev'
+  } catch {
+    return 'dev'
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  define: {
+    __APP_VERSION__: JSON.stringify(resolveVersion()),
+  },
 })


### PR DESCRIPTION
## Summary
- Replace hardcoded `1.0.0` in Settings > About and macOS `Info.plist` with a value resolved at build time.
- `vite.config.js` picks `APP_VERSION` env var if set, otherwise falls back to `dev-<short sha>` (or `dev`).
- CI `release.yaml` computes the version from the pushed tag (`v1.2.3` → `1.2.3`) and passes it to both the frontend build and the macOS packaging step, so UI and bundle metadata stay in sync on every release.

## Test plan
- [x] `npx vite build` locally → bundle embeds `dev-<sha>` for current HEAD.
- [x] `APP_VERSION=1.2.3 npx vite build` → bundle embeds `1.2.3`.
- [x] `go build` still succeeds.
- [ ] After merge, tagging `v0.3.4` triggers the release workflow and produced artifacts show `0.3.4` in Settings > About and in `Info.plist`.