### PR TITLE
fix: dashboard realtime updates, ping refresh, quieter notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ frontend/dist
 # Wails
 frontend/dist/
 frontend/node_modules/
+frontend/.vite/
 wailsjs/
 
 # Build artifacts

--- a/app.go
+++ b/app.go
@@ -132,7 +132,13 @@ func (a *App) GetStatus() MonitorStatus {
 	return a.manager.GetMonitorStatus()
 }
 
-func (a *App) PingRoute(host string) PingResult {
+func (a *App) PingRoute(ifaceName string, host string) PingResult {
+	if ifaceName != "" {
+		if err := a.manager.RefreshRoute(ifaceName, host); err != nil {
+			log.Printf("[warn] refresh route %s on %s: %v", host, ifaceName, err)
+		}
+	}
+
 	start := time.Now()
 	result := PingResult{Host: host}
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@ onMounted(async () => {
 
   Events.On('monitor:started', () => { monitor.fetchStatus() })
   Events.On('monitor:stopped', () => { monitor.fetchStatus() })
+  Events.On('interface:status-changed', (event) => { monitor.updateInterfaceStatus(event.data) })
 })
 </script>
 

--- a/frontend/src/stores/monitor.js
+++ b/frontend/src/stores/monitor.js
@@ -27,7 +27,11 @@ export const useMonitorStore = defineStore('monitor', () => {
 
   function updateInterfaceStatus(ifaceStatus) {
     const idx = status.value.interfaces.findIndex(i => i.interfaceName === ifaceStatus.interfaceName)
-    if (idx >= 0) status.value.interfaces[idx] = ifaceStatus
+    if (idx >= 0) {
+      status.value.interfaces[idx] = ifaceStatus
+    } else {
+      status.value.interfaces.push(ifaceStatus)
+    }
   }
 
   return { status, activeCount, totalRoutes, fetchStatus, startMonitor, stopMonitor, updateInterfaceStatus }

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { onMounted, ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Call, Events } from '@wailsio/runtime'
+import { Call } from '@wailsio/runtime'
 import { useMonitorStore } from '../stores/monitor'
 import { useConfigStore } from '../stores/config'
 
@@ -40,9 +40,6 @@ onMounted(async () => {
   try {
     systemInterfaces.value = await Call.ByName('main.App.GetNetworkInterfaces') || []
   } catch (e) { console.error('GetNetworkInterfaces failed:', e) }
-  Events.On('interface:status-changed', (event) => {
-    monitor.updateInterfaceStatus(event.data)
-  })
 })
 
 const uptime = computed(() => {
@@ -57,10 +54,10 @@ const uptime = computed(() => {
 
 function toggle(name) { expanded.value[name] = !expanded.value[name] }
 
-async function pingRoute(host) {
+async function pingRoute(ifaceName, host) {
   pingResults.value[host] = { loading: true }
   try {
-    const result = await Call.ByName('main.App.PingRoute', host)
+    const result = await Call.ByName('main.App.PingRoute', ifaceName, host)
     pingResults.value[host] = result
   } catch (e) {
     pingResults.value[host] = { reachable: false, error: e.toString() }
@@ -267,7 +264,7 @@ function isRouteActive(ifaceName, routeName) {
           <span v-if="getResolvedIps(iface.name, route).length" style="color: var(--text-secondary); user-select: text;">→ {{ getResolvedIps(iface.name, route).join(', ') }}</span>
           <button v-if="editing[iface.name]" @click="configStore.removeRoute(ifaceIdx, routeIdx)"
                   style="background: none; border: none; color: var(--text-secondary); cursor: pointer; font-size: 16px; padding: 0 4px;" :title="$t('routes.removeRoute')">×</button>
-          <button class="btn" style="font-size: 11px; padding: 2px 8px; margin-left: auto;" @click.stop="pingRoute(route)">
+          <button class="btn" style="font-size: 11px; padding: 2px 8px; margin-left: auto;" @click.stop="pingRoute(iface.name, route)">
             {{ pingResults[route]?.loading ? '...' : $t('dashboard.ping') }}
           </button>
           <span v-if="pingResults[route] && !pingResults[route].loading" style="font-size: 12px;"

--- a/manager.go
+++ b/manager.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -105,6 +106,22 @@ func (m *Manager) GetMonitorStatus() MonitorStatus {
 		Interfaces: statuses,
 		StartedAt:  m.startedAt,
 	}
+}
+
+func (m *Manager) RefreshRoute(ifaceName, forAddr string) error {
+	m.mu.Lock()
+	var target *nc.NetCatcher
+	for _, c := range m.catchers {
+		if c.Name() == ifaceName {
+			target = c
+			break
+		}
+	}
+	m.mu.Unlock()
+	if target == nil {
+		return fmt.Errorf("interface not found: %s", ifaceName)
+	}
+	return target.RefreshRoute(forAddr)
 }
 
 func (m *Manager) UpdateConfig(cfg config.Config) {

--- a/netcatcher/netcatcher.go
+++ b/netcatcher/netcatcher.go
@@ -66,6 +66,105 @@ func NewNetCatcher(cfg config.Interface, onStatus StatusCallback) *NetCatcher {
 	}
 }
 
+func (n *NetCatcher) Name() string {
+	return n.config.Name
+}
+
+func (n *NetCatcher) RefreshRoute(forAddr string) error {
+	if _, _, err := net.ParseCIDR(forAddr); err == nil {
+		return nil
+	}
+	if net.ParseIP(forAddr) != nil {
+		return nil
+	}
+
+	isConnected := n.current == connected
+
+	var gateway string
+	for _, r := range n.routes {
+		if r.gateway != "" {
+			gateway = r.gateway
+			break
+		}
+	}
+
+	var newIPs []net.IP
+	if isConnected && gateway != "" {
+		iface, ifaceErr := net.InterfaceByName(n.config.Name)
+		if ifaceErr == nil && iface != nil {
+			ips, err := lookupIPViaInterface(iface, gateway, n.config.DNS, forAddr)
+			if err != nil || len(ips) == 0 {
+				log.Printf("%s: [warn] refresh %s via %s fail %v; falling back to system resolver", n.config.Name, forAddr, iface.Name, err)
+			} else {
+				newIPs = ips
+			}
+		}
+	}
+	if len(newIPs) == 0 {
+		ips, err := net.LookupIP(forAddr)
+		if err != nil {
+			return fmt.Errorf("lookup %s: %w", forAddr, err)
+		}
+		newIPs = ips
+	}
+
+	entryGateway := gateway
+	if !isConnected {
+		entryGateway = ""
+	}
+
+	oldByIP := map[string]routeEntry{}
+	kept := make([]routeEntry, 0, len(n.routes))
+	for _, r := range n.routes {
+		if r.forAddr == forAddr {
+			oldByIP[r.ip] = r
+		} else {
+			kept = append(kept, r)
+		}
+	}
+
+	newEntries := make([]routeEntry, 0, len(newIPs))
+	newByIP := map[string]routeEntry{}
+	for _, ip := range newIPs {
+		ipStr := ip.String()
+		if _, dup := newByIP[ipStr]; dup {
+			continue
+		}
+		entry := routeEntry{forAddr: forAddr, ip: ipStr, gateway: entryGateway}
+		newByIP[ipStr] = entry
+		newEntries = append(newEntries, entry)
+	}
+
+	if isConnected && gateway != "" {
+		var toDelete, toAdd []route.RouteSpec
+		for ip, r := range oldByIP {
+			if _, ok := newByIP[ip]; !ok {
+				toDelete = append(toDelete, route.RouteSpec{Ip: r.ip, Gateway: r.gateway, Mask: r.mask})
+			}
+		}
+		for ip, r := range newByIP {
+			if _, ok := oldByIP[ip]; !ok {
+				toAdd = append(toAdd, route.RouteSpec{Ip: r.ip, Gateway: r.gateway, Mask: r.mask})
+			}
+		}
+
+		if len(toDelete) > 0 {
+			if err := route.DeleteRoutes(toDelete); err != nil {
+				log.Printf("%s: [warn] delete stale routes for %s: %v", n.config.Name, forAddr, err)
+			}
+		}
+		if len(toAdd) > 0 {
+			if err := route.AddRoutes(toAdd); err != nil {
+				log.Printf("%s: [warn] add refreshed routes for %s: %v", n.config.Name, forAddr, err)
+			}
+		}
+	}
+
+	n.routes = append(kept, newEntries...)
+	n.emitStatus()
+	return nil
+}
+
 func (n *NetCatcher) GetStatus() InterfaceStatus {
 	s := InterfaceStatus{
 		InterfaceName: n.config.Name,
@@ -152,7 +251,7 @@ func (n *NetCatcher) addRoutesTo(addr net.Addr) {
 }
 
 func (n *NetCatcher) clearRoutes() {
-	if len(n.routes) == 0 {
+	if len(n.routes) == 0 || n.current != connected {
 		return
 	}
 	specs := make([]route.RouteSpec, len(n.routes))

--- a/notify.go
+++ b/notify.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	nc "netcatcher/netcatcher"
@@ -11,12 +12,14 @@ import (
 )
 
 type Notifier struct {
-	enabled bool
-	svc     *notifications.NotificationService
+	enabled   bool
+	svc       *notifications.NotificationService
+	mu        sync.Mutex
+	lastState map[string]bool
 }
 
 func NewNotifier(svc *notifications.NotificationService) *Notifier {
-	return &Notifier{enabled: true, svc: svc}
+	return &Notifier{enabled: true, svc: svc, lastState: make(map[string]bool)}
 }
 
 func (n *Notifier) SetEnabled(enabled bool) {
@@ -28,6 +31,14 @@ func (n *Notifier) IsEnabled() bool {
 }
 
 func (n *Notifier) OnStatusChange(status nc.InterfaceStatus) {
+	n.mu.Lock()
+	prev, seen := n.lastState[status.InterfaceName]
+	n.lastState[status.InterfaceName] = status.Connected
+	n.mu.Unlock()
+	if !seen || prev == status.Connected {
+		return
+	}
+
 	if !n.enabled || n.svc == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

- Dashboard now updates live on VPN connect/disconnect without needing a tab switch (listener moved to `App.vue`; store append-if-missing).
- Clicking Ping on a domain route re-resolves via the interface's DNS, updates the OS routing table and UI, then pings. Works even when the interface is disconnected — resolve via system DNS, UI shows fresh IPs, no route-table changes.
- Saving config or quitting while the interface is disconnected no longer triggers the macOS admin prompt (`clearRoutes` is skipped — kernel already removed those routes).
- Desktop notifications now fire only on real connect↔disconnect transitions, not on every Ping/Save-triggered status emit.

## Test plan

- [ ] Start app on Dashboard tab, connect VPN → status/routes update within ~1s, no tab switch required.
- [ ] Click Ping on a domain route while connected → resolved IPs update if DNS changed; OS route table reflects new IPs.
- [ ] Click Ping on a domain route while disconnected → resolved IPs show in UI; no sudo prompt; no OS route changes.
- [ ] Save config while VPN disconnected → no admin prompt.
- [ ] Click Ping / Save while connected → no duplicate "connected" notification.
- [ ] Connect/disconnect VPN → one notification per actual transition.