### PR TITLE
ci: scope release secrets to the prod environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
             platform: windows
             goarch: amd64
     runs-on: ${{ matrix.os }}
+    environment: prod
     env:
       GOARCH: ${{ matrix.goarch }}
       CGO_ENABLED: 1
@@ -187,6 +188,7 @@ jobs:
   sign-checksums:
     needs: build
     runs-on: ubuntu-latest
+    environment: prod
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Adds `environment: prod` to the `build` and `sign-checksums` jobs in `.github/workflows/release.yaml`.
- Required so the workflow can read `NETCATCHER_UPDATE_VERIFY_PUBLIC_KEY` and `NETCATCHER_UPDATE_SIGNING_PRIVATE_KEY`, which were configured as Environment secrets (under `prod`) rather than repository secrets.

Without this, the upcoming v0.3.10 tag push would build with an empty pubkey (Ed25519 disabled) and the sign-checksums job would exit 2.

## Test plan

- [ ] YAML still parses
- [ ] Next tag push triggers a release run that successfully reads both secrets